### PR TITLE
148 add repository function get history query that returns all relevant satellite entries with state date start state date end and user

### DIFF
--- a/montrek/baseclasses/repositories/montrek_repository.py
+++ b/montrek/baseclasses/repositories/montrek_repository.py
@@ -214,7 +214,7 @@ class MontrekRepository:
             raise ValueError(
                 f"{time_series_satellite_class.__name__} is not a subclass of MontrekTimeSeriesSatelliteABC"
             )
-        queryset = time_series_satellite_class.objects.filter(
+        return time_series_satellite_class.objects.filter(
             state_date_start__lte=reference_date,
             state_date_end__gte=reference_date,
             value_date__lte=self.session_end_date,

--- a/montrek/montrek_example/tests/repositories/test_montrek_example_repository.py
+++ b/montrek/montrek_example/tests/repositories/test_montrek_example_repository.py
@@ -554,13 +554,13 @@ class TestHistory(TestCase):
             hub_entity=huba,
             field_a1_str="TestFeld",
             field_a1_int=5,
-            state_date_end="2024-02-17",
+            state_date_end=montrek_time(2024, 2, 17),
         )
         me_factories.SatA1Factory(
             hub_entity=huba,
             field_a1_str="TestFeld",
             field_a1_int=6,
-            state_date_start="2024-02-17",
+            state_date_start=montrek_time(2024, 2, 17),
         )
         me_factories.SatA2Factory(
             hub_entity=huba,


### PR DESCRIPTION
## How To Test

```python
from montrek_example.repositories.hub_a_repository import HubARepository
# Create first object
obj_1 = HubARepository().std_create_object(data={'field_a1_int': 1, 'field_a1_str': 'TestA1', 'field_a2_float': 3.0, 'field_a2_str': "TestA2"})
# See history:
changes = HubARepository().get_history_queryset(pk = obj1.pk)
print([(ch.change_date, ch.field_a1_str, ch.field_a1_int, ch.field_a2_str, ch.field_a2_float) for ch in changes.all()])
# Expected result:
#    [('0001-01-01 00:00:00+00:00', 'TestA1', 1, 'TestA2', 3.0)]
# Change entry and watch history:
HubARepository().std_create_object(data={'field_a1_int': 2, 'field_a1_str': 'TestA1', 'field_a2_float': 3.0, 'field_a2_str': "TestA2"})
changes = HubARepository().get_history_queryset(pk = obj1.pk)
print([(ch.change_date, ch.field_a1_str, ch.field_a1_int, ch.field_a2_str, ch.field_a2_float) for ch in changes.all()])
# Expected result:
# [('0001-01-01 00:00:00+00:00', 'TestA1', 1, 'TestA2', 3.0), ('2024-02-17 15:12:58.819099+00:00', 'TestA1', 2, 'TestA2', 3.0)]
```