### PR TITLE
158 navbar elements in env

### DIFF
--- a/montrek/baseclasses/views.py
+++ b/montrek/baseclasses/views.py
@@ -28,13 +28,6 @@ def under_construction(request):
 
 def navbar(request):
     navbar_apps_config = config("NAVBAR_APPS", default="").split(" ")
-    # navbar_apps = [
-    #    NavBarModel("account"),
-    #    NavBarModel("credit_institution"),
-    #    NavBarModel("asset"),
-    #    NavBarModel("currency"),
-    #    NavBarModel("country"),
-    # ]
     navbar_apps = [NavBarModel(app) for app in navbar_apps_config if app != ""]
     return render(request, "navbar.html", {"nav_apps": navbar_apps})
 


### PR DESCRIPTION
## What changed

Navbar elements are not hard-coded anymore, but called from .env file

## How To Test

- [x] Restart montrek; except for *Home* no elements should be in the NavBar
- [x] Add a variation of this to *.env*:

  ```
  NAVBAR_APPS= account credit_institution asset currency country
  ```
  - After a restart you should see the elements in the Navbar


