### PR TITLE
Catch any unhandled processor errors during background file import

### DIFF
--- a/montrek/file_upload/tests/tasks/test_process_file_task.py
+++ b/montrek/file_upload/tests/tasks/test_process_file_task.py
@@ -25,45 +25,79 @@ class TestProcessFileTaskABC(TestCase):
         )
         self.user = MontrekUserFactory()
         self.session_data = {"user_id": self.user.id}
+        self.registry_sat_obj = FileUploadRegistryStaticSatelliteFactory()
+        self.file_name = self.registry_sat_obj.file_name
+        self.file_path = f"/dummy/path/{self.file_name}"
 
     def test_run(self):
-        registry_sat_obj = FileUploadRegistryStaticSatelliteFactory()
-        file_path = f"/dummy/path/{registry_sat_obj.file_name}"
         result = self.task.delay(
-            file_path=file_path,
-            file_upload_registry_id=registry_sat_obj.hub_entity.id,
+            file_path=self.file_path,
+            file_upload_registry_id=self.registry_sat_obj.hub_entity.id,
             session_data=self.session_data,
         )
         self.assertTrue(result.successful())
         self.assertEqual(len(mail.outbox), 1)
         m = mail.outbox[0]
         self.assertEqual(m.to, [self.user.email])
-        self.assertEqual(m.subject, "Backgroud File Upload Finished")
+        self.assertEqual(
+            m.subject,
+            f"Background file upload finished successfully. ({self.file_name})",
+        )
         self.assertTrue(
             "File processed" in m.body,
         )
         registry_sat_obj = MockFileUploadRegistryRepository({}).std_queryset().last()
         self.assertEqual(registry_sat_obj.upload_status, "processed")
 
-    def test_run_error(self):
-        registry_sat_obj = FileUploadRegistryStaticSatelliteFactory()
-        file_path = f"/dummy/path/{registry_sat_obj.file_name}"
+    def test_run_handled_processor_error(self):
         self.task = ProcessFileTaskABC(
             file_upload_processor_class=MockFileUploadProcessorPostCheckFail,
             file_upload_registry_repository_class=FileUploadRegistryRepository,
         )
         result = self.task.delay(
-            file_path=file_path,
-            file_upload_registry_id=registry_sat_obj.hub_entity.id,
+            file_path=self.file_path,
+            file_upload_registry_id=self.registry_sat_obj.hub_entity.id,
             session_data=self.session_data,
         )
         self.assertTrue(result.successful())
         self.assertEqual(len(mail.outbox), 1)
         m = mail.outbox[0]
         self.assertEqual(m.to, [self.user.email])
-        self.assertEqual(m.subject, "Backgroud File Upload Finished")
+        self.assertEqual(
+            m.subject,
+            f"ERROR: Background file upload did not finish successfully! ({self.file_name})",
+        )
         self.assertTrue(
             "Post check failed" in m.body,
+        )
+        registry_sat_obj = FileUploadRegistryRepository({}).std_queryset().last()
+        self.assertEqual(registry_sat_obj.upload_status, "failed")
+
+    def test_run_unhandled_processor_error(self):
+        class ErrorFileUploadProcessor(MockFileUploadProcessor):
+            def __init__(self, *args, **kwargs):
+                raise RuntimeError("Processor error")
+
+        self.task = ProcessFileTaskABC(
+            file_upload_processor_class=ErrorFileUploadProcessor,
+            file_upload_registry_repository_class=FileUploadRegistryRepository,
+        )
+        result = self.task.delay(
+            file_path=self.file_path,
+            file_upload_registry_id=self.registry_sat_obj.hub_entity.id,
+            session_data=self.session_data,
+        )
+        self.assertTrue(result.successful())
+        self.assertEqual(len(mail.outbox), 1)
+        m = mail.outbox[0]
+        self.assertEqual(m.to, [self.user.email])
+        self.assertEqual(
+            m.subject,
+            f"ERROR: Background file upload did not finish successfully! ({self.file_name})",
+        )
+        self.assertTrue(
+            "Error raised during file processing: <br>RuntimeError: Processor error"
+            in m.body,
         )
         registry_sat_obj = FileUploadRegistryRepository({}).std_queryset().last()
         self.assertEqual(registry_sat_obj.upload_status, "failed")


### PR DESCRIPTION
Make background file processing task catch any errors which are not handled already by the processor. If an error is caught, the registry is updated and a mail sent with the error.