### PR TITLE
Make invalid JSON error visible

### DIFF
--- a/montrek/baseclasses/views.py
+++ b/montrek/baseclasses/views.py
@@ -395,10 +395,16 @@ class MontrekCreateUpdateView(
 
     def post(self, request, *args, **kwargs):
         # TODO: Form should receive manager
+        self.object = None
         form = self.form_class(self.request.POST, repository=self.manager.repository)
         if form.is_valid():
             return self.form_valid(form)
         return self.form_invalid(form)
+
+    def form_invalid(self, form):
+        msg = "\n".join([f"{k}: {', '.join(v)}" for k, v in form.errors.items()])
+        messages.error(self.request, msg)
+        return super().form_invalid(form)
 
 
 class MontrekCreateView(MontrekCreateUpdateView):

--- a/montrek/file_upload/views.py
+++ b/montrek/file_upload/views.py
@@ -106,6 +106,7 @@ class MontrekFieldMapCreateView(MontrekCreateView):
         )
 
     def post(self, request, *args, **kwargs):
+        self.object = None
         form = self.form_class(
             self.request.POST,
             repository=self.manager.repository,
@@ -134,6 +135,7 @@ class MontrekFieldMapUpdateView(MontrekUpdateView):
         )
 
     def post(self, request, *args, **kwargs):
+        self.object = None
         form = self.form_class(
             self.request.POST,
             repository=self.manager.repository,

--- a/montrek/montrek_example/tests/test_views.py
+++ b/montrek/montrek_example/tests/test_views.py
@@ -547,6 +547,18 @@ class TestMontrekExampleA1FieldMapCreateView(MontrekCreateViewTestCase):
         )
         self.assertEqual(form.initial["function_name"], "no_change")
 
+    def test_form_invalid_json(self):
+        creation_data = self.creation_data()
+        invalid_json_strings = ("abc", "{'a': 'b'}", "{1: 2}", "als;djf}")
+        for invalid_json in invalid_json_strings:
+            creation_data["function_parameters"] = invalid_json
+            response = self.client.post(self.url, creation_data)
+            messages = list(response.context["messages"])
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(messages), 1)
+            message = str(messages[0])
+            self.assertEqual(message, "function_parameters: Enter a valid JSON.")
+
 
 class TestMontrekExampleA1FieldMapUpdateView(MontrekCreateViewTestCase):
     viewname = "montrek_example_a1_field_map_update"


### PR DESCRIPTION
<img width="1039" alt="image" src="https://github.com/user-attachments/assets/21c5c73d-7ace-4e17-a364-571535600d92">

# Background
If we enter an invalid JSON in a creation form, then we are confronted with this error (see issue):

<img width="792" alt="image" src="https://github.com/user-attachments/assets/3deaef79-8d28-4b4d-a2c4-ea18d55296ef">

The reason is, that the view gets no `object` attribute set. The model object is not there, because it cannot be instantiated due to the faulty JSON. 

The parent class of `MontrekCreateUpdateView`, django's own `BaseCreateView`, handles this by setting the `object` attribute to `None`, *before* the object instantiation is attempted:

<img width="612" alt="image" src="https://github.com/user-attachments/assets/a4abc017-4e51-4485-882e-6a02bb42f2c2">

This setting of a `None` default is missing in our `post` method overrides. This PR fixes that.

Unfortunately, this will only prevent an error from being raised. There is no notification to the user about what is wrong with the form content. One can just click on `Create` and nothing happens. 

Therefore, I make another change in this MR which presents any form errors as a message to the user.