### PR TITLE
Add text table element

### DIFF
--- a/montrek/file_upload/managers/file_upload_registry_manager.py
+++ b/montrek/file_upload/managers/file_upload_registry_manager.py
@@ -7,6 +7,7 @@ from reporting.dataclasses.table_elements import (
     DateTableElement,
     LinkTableElement,
     StringTableElement,
+    TextTableElement,
 )
 
 
@@ -21,7 +22,7 @@ class FileUploadRegistryManagerABC(MontrekTableManager):
         table_elements = [
             StringTableElement(name="File Name", attr="file_name"),
             StringTableElement(name="Upload Status", attr="upload_status"),
-            StringTableElement(name="Upload Message", attr="upload_message"),
+            TextTableElement(name="Upload Message", attr="upload_message"),
             DateTableElement(name="Upload Date", attr="upload_date"),
             StringTableElement(name="Uploaded By", attr="created_by"),
             LinkTableElement(

--- a/montrek/reporting/dataclasses/table_elements.py
+++ b/montrek/reporting/dataclasses/table_elements.py
@@ -170,6 +170,14 @@ class StringTableElement(AttrTableElement):
 
 
 @dataclass
+class TextTableElement(AttrTableElement):
+    attr: str
+
+    def format(self, value):
+        return f'<td style="text-align: left; white-space: pre-wrap;">{value}</td>'
+
+
+@dataclass
 class AlertTableElement(AttrTableElement):
     attr: str
 

--- a/montrek/reporting/tests/dataclasses/test_table_elements.py
+++ b/montrek/reporting/tests/dataclasses/test_table_elements.py
@@ -19,6 +19,13 @@ class TestTableElements(TestCase):
             test_element.format(1234), '<td style="text-align: left">1234</td>'
         )
 
+    def test_text_table_element(self):
+        test_element = te.TextTableElement(name="test", attr="test_value")
+        self.assertEqual(
+            test_element.format("test"),
+            '<td style="text-align: left; white-space: pre-wrap;">test</td>',
+        )
+
     def test_float_table_elements(self):
         test_element = te.FloatTableElement(name="test", attr="test_value")
         self.assertEqual(


### PR DESCRIPTION
Small cosmetical idea for wrapping long texts in tables:

<img width="1128" alt="image" src="https://github.com/user-attachments/assets/40d81a15-a539-4e1c-b802-a1621042c760">
