### PR TITLE
Increase celery broker message re-queue timout

### DIFF
--- a/montrek/montrek/celery_app.py
+++ b/montrek/montrek/celery_app.py
@@ -1,7 +1,6 @@
 import os
 
 from celery import Celery
-from django.conf import settings
 from kombu import Queue
 
 SEQUENTIAL_QUEUE_NAME = "sequential_queue"
@@ -12,11 +11,11 @@ app = Celery(
     "montrek",
 )
 app.config_from_object("django.conf:settings", namespace="CELERY")
-app.conf.task_always_eager = settings.CELERY_TASK_ALWAYS_EAGER
 app.conf.task_queues = (
     Queue(SEQUENTIAL_QUEUE_NAME, routing_key=f"{SEQUENTIAL_QUEUE_NAME}.#"),
     Queue(PARALLEL_QUEUE_NAME, routing_key=f"{PARALLEL_QUEUE_NAME}.#"),
 )
+
 app.conf.task_default_queue = SEQUENTIAL_QUEUE_NAME
 
 app.autodiscover_tasks()

--- a/montrek/montrek/settings.py
+++ b/montrek/montrek/settings.py
@@ -201,6 +201,12 @@ EMAIL_TEMPLATE = config("EMAIL_TEMPLATE", "mail_templates/montrek_mail_template.
 CELERY_BROKER_URL = config("CELERY_BROKER_URL", default="redis://redis:6379")
 CELERY_RESULT_BACKEND = config("CELERY_RESULT_BACKEND", default="redis://redis:6379")
 CELERY_TASK_ALWAYS_EAGER = config("CELERY_TASK_ALWAYS_EAGER", default=True, cast=bool)
+# number of messages the worker can prefetch from the broker
+CELERY_WORKER_PREFETCH_MULTIPLIER = 1
+# time to wait for the worker to acknowledge the task before the message is re-queued
+CELERY_BROKER_TRANSPORT_OPTIONS = {
+    "visibility_timeout": 3600 * 10,  # 10 hours
+}
 
 LOGGING = {
     "version": 1,


### PR DESCRIPTION
Following, this should solve the issue https://stackoverflow.com/questions/27310899/celery-is-rerunning-long-running-completed-tasks-over-and-over/36873407#36873407

Tested locally with a long running task.