### PR TITLE
Pass hubs from static data generation to time series data generation

### DIFF
--- a/montrek/baseclasses/repositories/montrek_repository.py
+++ b/montrek/baseclasses/repositories/montrek_repository.py
@@ -229,9 +229,10 @@ class MontrekRepository:
         else:
             static_hubs = []
         if ts_columns:
-            ts_hubs = self._create_objects_from_data_frame(
-                data_frame.loc[:, ts_columns]
-            )
+            ts_df = data_frame.loc[:, ts_columns]
+            if static_hubs:
+                ts_df["hub_entity_id"] = [hub.pk for hub in static_hubs]
+            ts_hubs = self._create_objects_from_data_frame(ts_df)
         else:
             ts_hubs = []
         return list(set(static_hubs + ts_hubs))


### PR DESCRIPTION
If a dataframe with only data for links to other hubs (green; treated as static data) and time series data such as the following is passed to `create_objects_from_data_frame`.

<img width="334" alt="image" src="https://github.com/user-attachments/assets/bce33422-780f-43a4-a368-ab376d5bd2f0">

Then the static/link data creation creates 8 hubs for the links. And the time series data creation creates 8 *new* hubs for the time series data. But link and time series data should meet at the same hub.