### PR TITLE
Use hub id instead of hub value date id in test

### DIFF
--- a/montrek/montrek_example/tests/test_views.py
+++ b/montrek/montrek_example/tests/test_views.py
@@ -136,7 +136,7 @@ class TestMontrekExampleADelete(MontrekDeleteViewTestCase):
         me_factories.SatA2Factory(hub_entity=self.sata1.hub_entity)
 
     def url_kwargs(self) -> dict:
-        return {"pk": self.sata1.get_hub_value_date().hub.id}
+        return {"pk": self.sata1.hub_entity.id}
 
 
 class TestMontrekExampleAHistoryView(MontrekViewTestCase):


### PR DESCRIPTION
I hope I am not misunderstanding something here, but I think we have to delete by hub entity id right? I think the test only passes since the hub entity id and the hub value date id are coincidentally the same.