### PR TITLE
Fix db ports in docker setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,8 +41,6 @@ services:
     depends_on:
       - db
       - redis
-    environment:
-      - DB_HOST=${DEPLOY_HOST}
     networks:
       - montrek_network
 

--- a/mariadb.yml
+++ b/mariadb.yml
@@ -1,14 +1,14 @@
 services:
   db:
     image: mariadb:latest
-    command: --max_allowed_packet=64M
+    command: --max_allowed_packet=64M --port=${DB_PORT}
     environment:
       MYSQL_DATABASE: ${DB_NAME}
       MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
       MYSQL_USER: ${DB_USER}
       MYSQL_PASSWORD: ${DB_PASSWORD}
     ports:
-      - "${DB_PORT}:3306"
+      - "${DB_PORT}:${DB_PORT}"
     volumes:
       - db_data:/var/lib/mysql
     networks:

--- a/montrek/montrek/settings.py
+++ b/montrek/montrek/settings.py
@@ -132,8 +132,12 @@ DATABASES = {
         "NAME": config("DB_NAME", default="montrek_db"),
         "USER": config("DB_USER", default="root"),
         "PASSWORD": config("DB_PASSWORD"),
-        "HOST": config("DB_HOST", default="localhost"),
-        "PORT": config("DB_PORT", default=3306, cast=int),
+        "HOST": config(
+            "DB_HOST", default="localhost"
+        ),  # in docker setup: docker-compose service name (db)
+        "PORT": config(
+            "DB_PORT", default=3306, cast=int
+        ),  # in docker setup: internal docker container port
     }
 }
 

--- a/postgres.yml
+++ b/postgres.yml
@@ -2,13 +2,13 @@ services:
   db:
     image: postgres:latest
     shm_size: 256m
-    command: postgres -c jit=off
+    command: postgres -c jit=off -p ${DB_PORT}
     environment:
       POSTGRES_DB: ${DB_NAME}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_USER: ${DB_USER}
     ports:
-      - "${DB_PORT}:5432"
+      - "${DB_PORT}:${DB_PORT}"
     volumes:
       - db_data:/var/lib/postgresql/data
     networks:


### PR DESCRIPTION
Use the same database port within the docker container (and network) as the one which is exposed to the outside world. This fixes the issue and also reduces confusion.

Things worked before "by accident" since we usually set the DB_PORT to the default port, so internal and external docker ports coincided.

# Test 
- set `DB_PORT=9999` (or some other non-standard db port) and `DB_HOST=db`
- stop, start docker setup
- everything should work 

(To use the docker db with the local webserver, just change `DB_HOST` to `localhost`)