### PR TITLE
Add montrek details page

### DIFF
--- a/montrek/baseclasses/pages.py
+++ b/montrek/baseclasses/pages.py
@@ -1,3 +1,6 @@
+from baseclasses.repositories.montrek_repository import MontrekRepository
+
+
 class MontrekPage:
     page_title = "page_title not set!"
     show_date_range_selector = False
@@ -20,6 +23,25 @@ class MontrekPage:
                 tab.active = "active"
             else:
                 tab.active = ""
+
+
+class MontrekDetailsPage(MontrekPage):
+    repository_class: type[MontrekRepository]
+    title_field: str
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._raise_for_missing_pk(**kwargs)
+        self._set_page_title(pk=kwargs["pk"])
+
+    def _raise_for_missing_pk(self, **kwargs):
+        if "pk" not in kwargs:
+            raise ValueError(f"{self.__class__.__name__} needs pk specified in url!")
+
+    def _set_page_title(self, pk):
+        repository = self.repository_class({})
+        self.obj = repository.receive().get(pk=pk)
+        self.page_title = getattr(self.obj, self.title_field)
 
 
 class NoPage(MontrekPage):

--- a/montrek/baseclasses/tests/mocks.py
+++ b/montrek/baseclasses/tests/mocks.py
@@ -1,0 +1,62 @@
+from dataclasses import dataclass
+
+
+class MockQuerySet:
+    def __init__(self, *args):
+        self.items = args
+
+    def __iter__(self):
+        return iter(self.items)
+
+    def __len__(self):
+        return len(self.items)
+
+    def __getitem__(self, index):
+        return self.items[index]
+
+    def __eq__(self, other):
+        if isinstance(other, list):
+            return list(self.items) == other
+        return NotImplemented
+
+    def all(self):
+        return self.items
+
+    def count(self):
+        return len(self.items)
+
+    def get(self, pk):
+        return self.items[pk]
+
+
+@dataclass
+class MockData:
+    field: str
+    value: int
+
+
+@dataclass
+class MockField:
+    name: str
+
+
+class MockRepository:
+    def __init__(self, session_data):
+        self.session_data = session_data
+        self.messages = []
+        self.annotations = {}
+
+    def receive(self):
+        return MockQuerySet(
+            MockData("item1", 1), MockData("item2", 2), MockData("item3", 3)
+        )  # Dummy data for testing
+
+    def std_satellite_fields(self):
+        return [
+            MockField("item1"),
+            MockField("item2"),
+            MockField("item3"),
+        ]  # Dummy data for testing
+
+    def get_all_fields(self):
+        return ["item1", "item2", "item3"]

--- a/montrek/baseclasses/tests/test_pages.py
+++ b/montrek/baseclasses/tests/test_pages.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
-from baseclasses.pages import MontrekPage, NoPage
+from baseclasses.pages import MontrekDetailsPage, MontrekPage, NoPage
 from baseclasses.dataclasses.view_classes import TabElement
+from baseclasses.tests.mocks import MockRepository
 
 
 class MockMontrekPage(MontrekPage):
@@ -14,6 +15,11 @@ class MockMontrekPage(MontrekPage):
                 html_id="id_test",
             ),
         )
+
+
+class MockMontrekDetailsPage(MontrekDetailsPage):
+    repository_class = MockRepository
+    title_field = "field"
 
 
 class TestMontrekPage(TestCase):
@@ -35,3 +41,16 @@ class TestMontrekPage(TestCase):
         page = NoPage()
         with self.assertRaises(NotImplementedError):
             page.get_tabs()
+
+
+class TestMontrekDetailsPage(TestCase):
+    def test_montrek_details_page(self):
+        page = MockMontrekDetailsPage(pk=0)
+        self.assertEqual(page.page_title, "item1")
+
+    def test_montrek_details_page_no_pk(self):
+        with self.assertRaises(ValueError) as e:
+            MockMontrekDetailsPage()
+        self.assertEqual(
+            str(e.exception), "MockMontrekDetailsPage needs pk specified in url!"
+        )

--- a/montrek/baseclasses/tests/test_views.py
+++ b/montrek/baseclasses/tests/test_views.py
@@ -1,10 +1,10 @@
+from baseclasses.tests.mocks import MockRepository
 from user.tests.factories.montrek_user_factories import MontrekUserFactory
 from django.contrib.auth.models import AnonymousUser
 from django.test import TestCase, RequestFactory
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.contrib.messages.middleware import MessageMiddleware
 from django.contrib.messages import get_messages
-from dataclasses import dataclass
 from baseclasses.views import MontrekViewMixin
 from baseclasses.views import MontrekListView
 from baseclasses.dataclasses.montrek_message import (
@@ -14,64 +14,6 @@ from baseclasses.dataclasses.montrek_message import (
 from baseclasses.pages import MontrekPage
 from reporting.managers.montrek_table_manager import MontrekTableManager
 from reporting.dataclasses import table_elements as te
-
-
-class MockQuerySet:
-    def __init__(self, *args):
-        self.items = args
-
-    def __iter__(self):
-        return iter(self.items)
-
-    def __len__(self):
-        return len(self.items)
-
-    def __getitem__(self, index):
-        return self.items[index]
-
-    def __eq__(self, other):
-        if isinstance(other, list):
-            return list(self.items) == other
-        return NotImplemented
-
-    def all(self):
-        return self.items
-
-    def count(self):
-        return len(self.items)
-
-
-@dataclass
-class MockData:
-    field: str
-    value: int
-
-
-@dataclass
-class MockField:
-    name: str
-
-
-class MockRepository:
-    def __init__(self, session_data):
-        self.session_data = session_data
-        self.messages = []
-        self.annotations = {}
-
-    def receive(self):
-        return MockQuerySet(
-            MockData("item1", 1), MockData("item2", 2), MockData("item3", 3)
-        )  # Dummy data for testing
-
-    def std_satellite_fields(self):
-        return [
-            MockField("item1"),
-            MockField("item2"),
-            MockField("item3"),
-        ]  # Dummy data for testing
-
-    def get_all_fields(self):
-        return ["item1", "item2", "item3"]
 
 
 class MockRequester:


### PR DESCRIPTION
We use the same code for details pages in multiple places to set the page title based on the object which is viewed. This PR adds a dedicated `MontrekDetailsPage` class which can be reused.