### PR TITLE
Add nginx client ip whitelist

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - APP_PORT=${APP_PORT}
       - DEPLOY_PORT=${DEPLOY_PORT}
       - PROJECT_NAME=${PROJECT_NAME}
+      - NGINX_ALLOWED_CLIENT_IP=${NGINX_ALLOWED_CLIENT_IP}
     restart: "on-failure"
     networks:
       - montrek_network

--- a/montrek/montrek/settings.py
+++ b/montrek/montrek/settings.py
@@ -287,5 +287,11 @@ SEND_TABLE_BY_MAIL_LIMIT = config("SEND_TABLE_BY_MAIL_LIMIT", default=10000, cas
 
 ADMIN_MAILING_LIST = config("ADMIN_MAILING_LIST", default="")
 
+# Logging
 LOG_LEVEL = config("LOG_LEVEL", default="WARNING")
 LOGGING = get_logging_config(LOG_LEVEL, MONTREK_EXTENSION_APPS)
+
+
+# NGINX will only allow requests from this IP.
+# To specify a range of IPs, use CIDR notation like 192.168.1.0/24.
+NGINX_ALLOWED_CLIENT_IP = config("NGINX_ALLOWED_CLIENT_IP", default="all")

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -9,4 +9,4 @@ COPY nginx.conf.template /etc/nginx/conf.d/nginx.conf.template
 COPY certs/cert.crt /etc/ssl/cert.crt
 COPY certs/cert.key /etc/ssl/cert.key
 
-CMD /bin/sh -c "envsubst '\$APP_PORT \$DEPLOY_PORT \$PROJECT_NAME' < /etc/nginx/conf.d/nginx.conf.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
+CMD /bin/sh -c "envsubst '\$APP_PORT \$DEPLOY_PORT \$PROJECT_NAME \$NGINX_ALLOWED_CLIENT_IP' < /etc/nginx/conf.d/nginx.conf.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -20,6 +20,8 @@ server {
         proxy_connect_timeout 60;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-Host $host:${DEPLOY_PORT};
+        deny all;
+        allow ${NGINX_ALLOWED_CLIENT_IP};
     }
     location /static/ {
         alias /montrek/static/; # where our static files are hosted


### PR DESCRIPTION
- Per default, requests from any ip address are permitted
- Add a made up ip to `.env`: `NGINX_ALLOWED_CLIENT_IP='129.0.0.1'`, rebuild nginx image, try to access montrek:
<img width="1224" alt="image" src="https://github.com/user-attachments/assets/79521b8d-f273-432f-a39a-f1c7ff07cb52" />

<img width="1385" alt="image" src="https://github.com/user-attachments/assets/ca1b17a5-0345-43a5-9bd9-3eeb56a2810e" />

