### PR TITLE
Set nginx listen port to DEPLOY_PORT

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   nginx:
     build: ./nginx
     ports:
-      - ${DEPLOY_PORT}:80
+      - ${DEPLOY_PORT}:${DEPLOY_PORT}
     volumes:
       - static_volume:/montrek/static
       - uploads_volume:/montrek/uploads

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -6,7 +6,7 @@ server {
 
 
     server_name montrek.${PROJECT_NAME};
-    listen 80 ssl;
+    listen ${DEPLOY_PORT} ssl;
     ssl_certificate /etc/ssl/cert.crt;
     ssl_certificate_key /etc/ssl/cert.key;
 


### PR DESCRIPTION
Browsers send https request to port 443 per default. We can add `DEPLOY_PORT=443` to .env and with this PR nginx will  listen on port 443. This means, that we can visit montrek in the browser just at `https://<ip>` *without a port specified*.