### PR TITLE
Add table element for long lists

### DIFF
--- a/montrek/reporting/dataclasses/table_elements.py
+++ b/montrek/reporting/dataclasses/table_elements.py
@@ -189,6 +189,19 @@ class TextTableElement(AttrTableElement):
 
 
 @dataclass
+class ListTableElement(AttrTableElement):
+    serializer_field_class = serializers.CharField
+    attr: str
+    in_separator: str = ","
+    out_separator: str = "<br>"
+
+    def format(self, value):
+        values = value.split(self.in_separator)
+        out_value = self.out_separator.join(values)
+        return f'<td style="text-align: left">{out_value}</td>'
+
+
+@dataclass
 class AlertTableElement(AttrTableElement):
     serializer_field_class = serializers.CharField
     attr: str
@@ -266,7 +279,7 @@ class ProgressBarTableElement(NumberTableElement):
 
     def format_latex(self, value) -> str:
         per_value = value * 100
-        return f"\\progressbar{{ {per_value } }}{{ {per_value}\\% }} &"
+        return f"\\progressbar{{ {per_value} }}{{ {per_value}\\% }} &"
 
 
 @dataclass

--- a/montrek/reporting/tests/dataclasses/test_table_elements.py
+++ b/montrek/reporting/tests/dataclasses/test_table_elements.py
@@ -26,6 +26,20 @@ class TestTableElements(TestCase):
             '<td style="text-align: left; white-space: pre-wrap;">test</td>',
         )
 
+    def test_list_table_element(self):
+        test_element = te.ListTableElement(name="test", attr="test_value")
+        self.assertEqual(
+            test_element.format("test1,test2"),
+            '<td style="text-align: left">test1<br>test2</td>',
+        )
+        test_element = te.ListTableElement(
+            name="test", attr="test_value", in_separator=";", out_separator="|"
+        )
+        self.assertEqual(
+            test_element.format("test1,2;test3;test4"),
+            '<td style="text-align: left">test1,2|test3|test4</td>',
+        )
+
     def test_float_table_elements(self):
         test_element = te.FloatTableElement(name="test", attr="test_value")
         self.assertEqual(


### PR DESCRIPTION
Table element which allows to format long csv list with line breaks:

<img width="620" alt="image" src="https://github.com/user-attachments/assets/b45a1d12-e7c9-44ca-b7d4-2ca79b6edb71" />
