### PR TITLE
Enable files in create template

### DIFF
--- a/montrek/baseclasses/templates/montrek_create.html
+++ b/montrek/baseclasses/templates/montrek_create.html
@@ -14,7 +14,7 @@
       <h2 id="id_title">{{ tag }}</h1> <!-- Centered the title and added bottom margin -->
     </div>
     <div class="row"> <!-- Centered the title for better alignment -->
-      <form method="post">
+      <form method="post" enctype="multipart/form-data">
         {% csrf_token %}
         <div class="table-responsive"> <!-- Made table responsive -->
           <table class="table table-bordered table-hover"> <!-- Applied Bootstrap table styles -->


### PR DESCRIPTION
A small change which makes it possible to use the optionally use the `montrek_create.html` template for file upload views. This makes file upload views with extra parameters look a bit nicer:

<img width="926" alt="image" src="https://github.com/user-attachments/assets/62c765e3-1753-4c97-80ec-b6ef7a9ed54d" />
