### PR TITLE
Add static kwarg in Link Table Element

### DIFF
--- a/montrek/reporting/dataclasses/table_elements.py
+++ b/montrek/reporting/dataclasses/table_elements.py
@@ -97,6 +97,7 @@ class BaseLinkTableElement(TableElement):
     url: str
     kwargs: dict
     hover_text: str
+    static_kwargs = {}
 
     @staticmethod
     def get_dotted_attr_or_arg(obj, value):
@@ -129,6 +130,7 @@ class BaseLinkTableElement(TableElement):
             if key != "filter"
         }
         kwargs = {key: str(value).replace("/", "_") for key, value in kwargs.items()}
+        kwargs.update(self.static_kwargs)
         return kwargs
 
     def _get_url(self, obj: Any, url_kwargs: dict) -> str:
@@ -167,6 +169,7 @@ class BaseLinkTableElement(TableElement):
 @dataclass
 class LinkTableElement(BaseLinkTableElement):
     icon: str
+    static_kwargs: dict = field(default_factory=dict)
 
     def _get_link_text(self, obj):
         return Template(
@@ -178,6 +181,7 @@ class LinkTableElement(BaseLinkTableElement):
 class LinkTextTableElement(BaseLinkTableElement):
     serializer_field_class = serializers.CharField
     text: str
+    static_kwargs: dict = field(default_factory=dict)
 
     def _get_link_text(self, obj):
         return BaseLinkTableElement.get_dotted_attr_or_arg(obj, self.text)

--- a/montrek/reporting/tests/dataclasses/test_table_elements.py
+++ b/montrek/reporting/tests/dataclasses/test_table_elements.py
@@ -425,6 +425,19 @@ class TestDataTableFilters(TestCase):
             in test_link
         )
 
+    def test__get_link_static_kwargs(self):
+        test_obj = TestMontrekSatelliteFactory.create()
+        table_element = te.LinkTextTableElement(
+            name="name",
+            url="dummy_detail_static",
+            text="test_name",
+            hover_text="hover_text",
+            kwargs={"pk": "pk", "filter": "test_name"},
+            static_kwargs={"static": "test_static"},
+        )
+        test_kwargs = table_element._get_url_kwargs(test_obj)
+        self.assertEqual(test_kwargs["static"], "test_static")
+
     def test_get_attribute(self):
         test_obj = TestMontrekSatelliteFactory.create(test_name="Test Name")
         table_element = te.LinkTableElement(


### PR DESCRIPTION
When the url of the target link should contain a value, which is not derived from the underlying object, `static_kwargs` is used to pass this value directly into the url.