### PR TITLE
Unbound form

### DIFF
--- a/montrek/reporting/mixins/view_form_mixin.py
+++ b/montrek/reporting/mixins/view_form_mixin.py
@@ -52,6 +52,6 @@ class ViewFormMixin(HasFormInvalid, HasSessionData):
 
     def get_form(self, request):
         self._report_form = self.report_form_class(
-            data=request.GET, session_data=self.session_data
+            data=request.GET or None, session_data=self.session_data
         )
         return self._report_form


### PR DESCRIPTION
In view_form_mixin.py:54, get_form always passes data=request.GET to the form — even on the initial GET request with no parameters. Django treats any non-None data
  argument as binding the form, so self.is_bound is always True, and the if not self.is_bound: block in DateSelectionReportFormBase.__init__ never executes.

  The fix is the standard Django pattern: pass request.GET or None, so an empty QueryDict becomes None (unbound form):
